### PR TITLE
Add photonvision configs

### DIFF
--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -168,12 +168,18 @@ namespace CONSTANTS
     constexpr units::angle::degree_t POSITION_THRESHOLD = 5_deg;
   }; // namespace WRIST
 
-  namespace VISION
-  {
-    static const auto LEFT_CAMERA_A_TF = frc::Transform3d{
-        0.151_m, 0.319_m, 0.578_m, frc::Rotation3d(180_deg, -10_deg, 90_deg)};
-    static const auto RIGHT_CAMERA_A_TF = frc::Transform3d{
-        0.151_m, -0.319_m, 0.578_m, frc::Rotation3d(180_deg, -10_deg, -90_deg)};
+namespace VISION {
+  /* Transforms from 2024:
+  static const auto LEFT_CAMERA_A_TF = frc::Transform3d{
+    0.151_m, 0.319_m, 0.578_m, frc::Rotation3d(180_deg, -10_deg, 90_deg)};
+  static const auto RIGHT_CAMERA_A_TF = frc::Transform3d{
+    0.151_m, -0.319_m, 0.578_m, frc::Rotation3d(180_deg, -10_deg, -90_deg)};
+  */
+
+  static const auto LEFT_CAMERA_A_TF = frc::Transform3d{
+    -1.25_in, 10.75_in, 39.488_in, frc::Rotation3d(0_deg, 0_deg, 10_deg)};
+  static const auto RIGHT_CAMERA_A_TF = frc::Transform3d{
+    -1.25_in, -10.75_in, 39.488_m, frc::Rotation3d(0_deg, 0_deg, -10_deg)};
 
   } // namespace VISION
 

--- a/src/main/include/swerve/Vision.h
+++ b/src/main/include/swerve/Vision.h
@@ -89,9 +89,8 @@ private:
         layout, photon::PoseStrategy::LOWEST_AMBIGUITY,
         CONSTANTS::VISION::RIGHT_CAMERA_A_TF};
 
-    std::vector<PhotonGroup> m_photoncam_vec{};
-    // std::vector<PhotonGroup> m_photoncam_vec = {{m_left_camera_a, m_left_estimator_a, m_single_left_estimator},
-    // {m_right_camera_a, m_right_estimator_a, m_single_right_estimator}};
+    std::vector<PhotonGroup> m_photoncam_vec = {{m_left_camera_a, m_left_estimator_a, m_single_left_estimator},
+    {m_right_camera_a, m_right_estimator_a, m_single_right_estimator}};
 
     std::pair<std::shared_ptr<nt::NetworkTable>, std::string> m_left_limelight =
         {nt::NetworkTableInstance::GetDefault().GetTable("limelight-left"), "limelight-left"};


### PR DESCRIPTION
Updates the camera geometry and enables the PhotonVision system to provide pose data for its two cameras. 