### PR TITLE
Corrected problem with conversion to/from ChassisSpeeds

### DIFF
--- a/src/main/cpp/swerve/SwerveModule.cpp
+++ b/src/main/cpp/swerve/SwerveModule.cpp
@@ -180,12 +180,12 @@ void SwerveModule::setDesiredState(frc::SwerveModuleState &desired_state)
 
 inline units::turns_per_second_t SwerveModule::bot_speed_to_wheel_speed(units::meters_per_second_t bot_speed)
 {
-    return bot_speed / (1_in / 1_tr);
+    return bot_speed / WHEEL_CIRCUMFERENCE;
 }
 
 inline units::meters_per_second_t SwerveModule::wheel_speed_to_bot_speed(units::turns_per_second_t wheel_speed)
 {
-    return wheel_speed * (1_in / 1_tr);
+    return wheel_speed * WHEEL_CIRCUMFERENCE;
 }
 
 void SwerveModule::percentOutputControl(double const &percent_output)

--- a/src/main/cpp/swerve/Trajectory.cpp
+++ b/src/main/cpp/swerve/Trajectory.cpp
@@ -55,8 +55,8 @@ Trajectory::Trajectory(Drivetrain *drivetrain, Odometry *odometry,
       },
       std::make_shared<pathplanner::PPHolonomicDriveController>(
           pathplanner::PIDConstants(
-              1.75, 0, 0.0),                       // Translation PID constants. Originally 1P
-          pathplanner::PIDConstants(0.625, 0.0, 0) // Rotation PID constants
+              5.0, 0.0, 0.0),                       // Translation PID constants. Originally 1P
+          pathplanner::PIDConstants(5.0, 0.0, 0) // Rotation PID constants
                                                    // T: 1.75, 0, 0.0
                                                    // R: 0.625, 0.0, 0
           ),

--- a/src/main/deploy/pathplanner/autos/left 4gp.auto
+++ b/src/main/deploy/pathplanner/autos/left 4gp.auto
@@ -5,6 +5,12 @@
     "data": {
       "commands": [
         {
+          "type": "named",
+          "data": {
+            "name": "l2"
+          }
+        },
+        {
           "type": "parallel",
           "data": {
             "commands": [
@@ -49,12 +55,6 @@
           }
         },
         {
-          "type": "named",
-          "data": {
-            "name": "idle"
-          }
-        },
-        {
           "type": "parallel",
           "data": {
             "commands": [
@@ -65,16 +65,53 @@
                 }
               },
               {
-                "type": "sequential",
+                "type": "named",
                 "data": {
-                  "commands": [
-                    {
-                      "type": "named",
-                      "data": {
-                        "name": "l4"
-                      }
-                    }
-                  ]
+                  "name": "l4"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "score_l4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "l2"
+          }
+        },
+        {
+          "type": "sequential",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "(LF)reef_(L)coral1"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "(L)coral_(F)reef"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "l4"
                 }
               }
             ]

--- a/src/main/deploy/pathplanner/paths/(L)coral_(F)reef.path
+++ b/src/main/deploy/pathplanner/paths/(L)coral_(F)reef.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 1.685593220338983,
-        "y": 0.8050599179025426
+        "x": 1.446,
+        "y": 1.009
       },
       "prevControl": null,
       "nextControl": {
-        "x": 2.092407336227932,
-        "y": 1.64229928104402
+        "x": 2.152399674405361,
+        "y": 1.715399674405361
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 3.2076001619037826,
-        "y": 3.854327392578125
+        "x": 3.6211900684931506,
+        "y": 2.928125
       },
       "prevControl": {
-        "x": 3.0159141732121544,
-        "y": 3.6938391321373287
+        "x": 2.9870672470799153,
+        "y": 2.3591034286480053
       },
       "nextControl": null,
       "isLocked": false,
@@ -29,12 +29,33 @@
     }
   ],
   "rotationTargets": [],
-  "constraintZones": [],
+  "constraintZones": [
+    {
+      "name": "Constraints Zone",
+      "minWaypointRelativePos": 0.7666666666666667,
+      "maxWaypointRelativePos": 1.0,
+      "constraints": {
+        "maxVelocity": 1.53,
+        "maxAcceleration": 2.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
   "pointTowardsZones": [],
-  "eventMarkers": [],
+  "eventMarkers": [
+    {
+      "name": "intake",
+      "waypointRelativePos": 0.0,
+      "endWaypointRelativePos": 1.0,
+      "command": null
+    }
+  ],
   "globalConstraints": {
-    "maxVelocity": 0.5,
-    "maxAcceleration": 0.75,
+    "maxVelocity": 1.5,
+    "maxAcceleration": 1.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -42,13 +63,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": 0.0
+    "rotation": 58.7
   },
   "reversed": false,
   "folder": "left_4gp",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 66.20194387842905
+    "rotation": 50.0
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/(L)coral_(LF)reef1.path
+++ b/src/main/deploy/pathplanner/paths/(L)coral_(LF)reef1.path
@@ -4,24 +4,24 @@
     {
       "anchor": {
         "x": 1.446,
-        "y": 1.09
+        "y": 1.009
       },
       "prevControl": null,
       "nextControl": {
-        "x": 2.0790996394063246,
-        "y": 1.6419193099028462
+        "x": 2.926577869464482,
+        "y": 1.990788391655906
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 3.963,
-        "y": 2.7899977095390636
+        "x": 3.936729452054794,
+        "y": 2.7628424657534243
       },
       "prevControl": {
-        "x": 3.194607479700043,
-        "y": 2.130602683525222
+        "x": 3.065239726027397,
+        "y": 1.365453767123287
       },
       "nextControl": null,
       "isLocked": false,
@@ -33,10 +33,10 @@
     {
       "name": "eepy time",
       "minWaypointRelativePos": 0.7576953433307025,
-      "maxWaypointRelativePos": 0.9707971586424626,
+      "maxWaypointRelativePos": 1.0,
       "constraints": {
         "maxVelocity": 1.0,
-        "maxAcceleration": 0.75,
+        "maxAcceleration": 2.0,
         "maxAngularVelocity": 540.0,
         "maxAngularAcceleration": 720.0,
         "nominalVoltage": 12.0,
@@ -45,10 +45,17 @@
     }
   ],
   "pointTowardsZones": [],
-  "eventMarkers": [],
+  "eventMarkers": [
+    {
+      "name": "intake",
+      "waypointRelativePos": 0.0,
+      "endWaypointRelativePos": 0.7,
+      "command": null
+    }
+  ],
   "globalConstraints": {
-    "maxVelocity": 4.0,
-    "maxAcceleration": 1.5,
+    "maxVelocity": 2.0,
+    "maxAcceleration": 2.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -62,7 +69,7 @@
   "folder": "left_4gp",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 53.430404214080646
+    "rotation": 50.0
   },
   "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/(L)start_(LB)reef.path
+++ b/src/main/deploy/pathplanner/paths/(L)start_(LB)reef.path
@@ -8,20 +8,20 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 5.712251683285362,
-        "y": 2.2512226305509864
+        "x": 6.047267483414177,
+        "y": 2.568102358695096
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.175255681818181,
-        "y": 3.0727130681818178
+        "x": 5.319092465753425,
+        "y": 2.9130993150684934
       },
       "prevControl": {
-        "x": 5.505513378672623,
-        "y": 2.7050584886176736
+        "x": 5.784888698630136,
+        "y": 2.176840753424658
       },
       "nextControl": null,
       "isLocked": false,
@@ -34,12 +34,26 @@
       "rotationDegrees": 120.80490628394956
     }
   ],
-  "constraintZones": [],
+  "constraintZones": [
+    {
+      "name": "Constraints Zone",
+      "minWaypointRelativePos": 0.42619047619047595,
+      "maxWaypointRelativePos": 1.0,
+      "constraints": {
+        "maxVelocity": 1.0,
+        "maxAcceleration": 2.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 0.5,
-    "maxAcceleration": 0.75,
+    "maxVelocity": 4.0,
+    "maxAcceleration": 2.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,

--- a/src/main/deploy/pathplanner/paths/(LB)reef_(L)coral.path
+++ b/src/main/deploy/pathplanner/paths/(LB)reef_(L)coral.path
@@ -8,20 +8,20 @@
       },
       "prevControl": null,
       "nextControl": {
-        "x": 3.6811654991639644,
-        "y": 1.7587369151861407
+        "x": 3.448401354772009,
+        "y": 2.248570455650531
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 1.4458806818181815,
-        "y": 1.00859375
+        "x": 1.446,
+        "y": 1.009
       },
       "prevControl": {
-        "x": 1.866657269785771,
-        "y": 2.013529662644478
+        "x": 1.9835350963808436,
+        "y": 1.7542833748301079
       },
       "nextControl": null,
       "isLocked": false,
@@ -47,7 +47,7 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 4.0,
+    "maxVelocity": 2.0,
     "maxAcceleration": 2.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
@@ -55,8 +55,8 @@
     "unlimited": false
   },
   "goalEndState": {
-    "velocity": 0,
-    "rotation": 49.36236310045944
+    "velocity": 0.0,
+    "rotation": 50.0
   },
   "reversed": false,
   "folder": "left_4gp",

--- a/src/main/deploy/pathplanner/paths/(LF)reef_(L)coral1.path
+++ b/src/main/deploy/pathplanner/paths/(LF)reef_(L)coral1.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 3.7794160487288133,
-        "y": 2.7806549589512715
+        "x": 3.981806506849315,
+        "y": 2.717765410958904
       },
       "prevControl": null,
       "nextControl": {
-        "x": 2.6292450383579977,
-        "y": 1.791894785114356
+        "x": 3.4108304794520548,
+        "y": 1.9214041095890413
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 1.4749072910930616,
-        "y": 0.7705776130575441
+        "x": 1.446,
+        "y": 1.009
       },
       "prevControl": {
-        "x": 3.316937689274017,
-        "y": 2.357234264386232
+        "x": 2.2087846699092943,
+        "y": 2.1458027741659365
       },
       "nextControl": null,
       "isLocked": false,
@@ -29,12 +29,26 @@
     }
   ],
   "rotationTargets": [],
-  "constraintZones": [],
+  "constraintZones": [
+    {
+      "name": "Constraints Zone",
+      "minWaypointRelativePos": 0.814285714285714,
+      "maxWaypointRelativePos": 1.0,
+      "constraints": {
+        "maxVelocity": 1.6,
+        "maxAcceleration": 2.0,
+        "maxAngularVelocity": 540.0,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 0.5,
-    "maxAcceleration": 0.75,
+    "maxVelocity": 2.0,
+    "maxAcceleration": 2.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,
@@ -42,7 +56,7 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": 55.375337077790576
+    "rotation": 50.0
   },
   "reversed": false,
   "folder": "left_4gp",
@@ -50,5 +64,5 @@
     "velocity": 0,
     "rotation": 63.087230076063776
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }


### PR DESCRIPTION
Corrected problem with conversion to/from ChassisSpeeds. Use WHEEL_CIRCUMFERENCE as proper conversion factor. Auto paths are much better behaved and wheel odometry tracks much better now. Also, update auto paths and returned to the PathPlanner default PID values