### PR TITLE
Remove the hack for robot max speed

### DIFF
--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -198,7 +198,7 @@ namespace CONSTANTS
   namespace DRIVE
   {
     constexpr units::second_t BRAKE_TIME = 10_s;
-    constexpr units::meters_per_second_t ROBOT_MAX_SPEED = 8_fps;
+    constexpr units::meters_per_second_t ROBOT_MAX_SPEED = 14.533_fps;
     constexpr units::radians_per_second_t ROBOT_MAX_ANGULAR_SPEED{std::numbers::pi *
                                                                   3};
     constexpr units::meters_per_second_t TELEOP_MAX_SPEED = ROBOT_MAX_SPEED;


### PR DESCRIPTION
The robot max speed was hacked to match the range of joystick input. Now that the ChassisSpeeds bug is fixed, use the real value for max speed.